### PR TITLE
Fix issue #10 and check for existence of env_file

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -88,6 +88,11 @@ do
     --env-file)
       ((++i))
       ENV_FILE="${argv[$i]}"
+      if [ ! -f "${ENV_FILE}" ];
+      then
+        echo "The specified environment file \"${ENV_FILE}\" does not exist, exiting..."
+        exit 1
+      fi
       ;;
 
     --date)

--- a/scripts/container-build.sh
+++ b/scripts/container-build.sh
@@ -287,7 +287,7 @@ then
   # The default is:
   # rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--
   # Add 'rv32imaf-ilp32f--'. 
-  GCC_MULTILIB=(rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imaf-ilp32f-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--)
+  GCC_MULTILIB=${GCC_MULTILIB:-"rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imaf-ilp32f-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--"}
 
   GCC_MULTILIB_FILE=${GCC_MULTILIB_FILE:-"t-elf-multilib"}
 
@@ -353,7 +353,7 @@ then
   # The default is:
   # rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--
   # Add 'rv32imaf-ilp32f--'. 
-  GCC_MULTILIB=(rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imaf-ilp32f-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--)
+  GCC_MULTILIB=${GCC_MULTILIB:-"rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imaf-ilp32f-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--"}
 
   GCC_MULTILIB_FILE=${GCC_MULTILIB_FILE:-"t-elf-multilib"}
 
@@ -421,7 +421,7 @@ then
   # The default is:
   # rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--
   # Add 'rv32imaf-ilp32f--'. 
-  GCC_MULTILIB=(rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imaf-ilp32f-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--)
+  GCC_MULTILIB=${GCC_MULTILIB:-"rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imaf-ilp32f-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--"}
 
   GCC_MULTILIB_FILE=${GCC_MULTILIB_FILE:-"t-elf-multilib"}
 
@@ -487,7 +487,7 @@ then
   # The default is:
   # rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--
   # Add 'rv32imaf-ilp32f--'. 
-  GCC_MULTILIB=(rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imaf-ilp32f-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--)
+  GCC_MULTILIB=${GCC_MULTILIB:-"rv32i-ilp32--c rv32im-ilp32--c rv32iac-ilp32-- rv32imac-ilp32-- rv32imaf-ilp32f-- rv32imafc-ilp32f-rv32imafdc- rv64imac-lp64-- rv64imafdc-lp64d--"}
 
   GCC_MULTILIB_FILE=${GCC_MULTILIB_FILE:-"t-elf-multilib"}
 

--- a/scripts/container-gcc-functions-source.sh
+++ b/scripts/container-gcc-functions-source.sh
@@ -276,7 +276,11 @@ function do_gcc_first()
 
         # Be sure the ${GCC_MULTILIB} has no quotes, since it defines 
         # multiple strings.
-        ./multilib-generator ${GCC_MULTILIB[@]} >"${GCC_MULTILIB_FILE}"
+
+        # Change IFS temporarily so that we can pass a simple string of
+        # whitespace delimited multilib tokens to multilib-generator
+        local IFS=$' '
+        ./multilib-generator ${GCC_MULTILIB} > "${GCC_MULTILIB_FILE}"
         cat "${GCC_MULTILIB_FILE}"
       )
     fi


### PR DESCRIPTION
Fix for issue #10:

1. Change default GCC_MULTILIB values from arrays to simple strings containing whitespace delimited multilib specification tokens - i.e. remove the surrounding brackets around the values that previously made them arrays.

1. Allow GCC_MULTILIB value to be overridden from an env_file - i.e. GCC_MULTILIB=${GCC_MULTILIB:-"..."}

1. Before calling multilib-generator locally switch IFS=$' ' to allow simple string to be passed to the script instead of needing it as an array.

Also - if --env-file is used then check that the env_file exists and exit if it does not. When testing I inadvertently specified my env_file name incorrectly and didn't know that the build ran with no env_file overrides.